### PR TITLE
Use JSON return values

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -9,6 +9,17 @@ pub struct Error {
     pub message: String,
 }
 
+impl From<String> for Error {
+    fn from(value: String) -> Self {
+        Error { message: value }
+    }
+}
+
+impl From<&str> for Error {
+    fn from(value: &str) -> Self {
+        Error { message: value.to_string() }
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct User {
@@ -118,7 +129,7 @@ impl Model {
         return new_user_entry;
     }
 
-    pub fn new_account(&self, account_holder: Uuid) -> Result<Account, String> {
+    pub fn new_account(&self, account_holder: Uuid) -> Result<Account, Error> {
         self.users.read().unwrap().get(&account_holder).ok_or("account holder not found")?;
 
         let new_account = Account::new_with_id(account_holder);
@@ -127,18 +138,18 @@ impl Model {
         return Ok(new_account);
     }
 
-    pub fn apply_deposit(&self, deposit: Deposit) -> Result<Account, String> {
+    pub fn apply_deposit(&self, deposit: Deposit) -> Result<Account, Error> {
         let mut unlocked_accounts = self.accounts.write().unwrap();
         let account = unlocked_accounts.get_mut(&deposit.account_id).ok_or("account not found")?;
         account.balance.amount += deposit.deposit_value.amount;
         Ok(account.clone())
     }
 
-    pub fn apply_withdraw(&self, deposit: Widthdrawal) -> Result<Account, String> {
+    pub fn apply_withdraw(&self, deposit: Widthdrawal) -> Result<Account, Error> {
         let mut unlocked_accounts = self.accounts.write().unwrap();
         let account = unlocked_accounts.get_mut(&deposit.account_id).ok_or("account not found")?;
         if account.balance.amount < deposit.deposit_value.amount {
-            Err("Insufficient funds".to_string())
+            Err(Error{message: "Insufficient funds".to_string()})
         }
         else {
             account.balance.amount -= deposit.deposit_value.amount;

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,6 +3,13 @@ use std::sync::RwLock;
 use rocket::serde::{Serialize, Deserialize};
 use uuid::Uuid;
 
+
+#[derive(Serialize, Deserialize)]
+pub struct Error {
+    pub message: String,
+}
+
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct User {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -3,7 +3,7 @@ use rocket::response::status::{BadRequest, NotFound};
 use rocket::serde::json::Json;
 
 use uuid::Uuid;
-use crate::model::{Account, Deposit, Model, User, Widthdrawal};
+use crate::model::{Account, Deposit, Error, Model, User, Widthdrawal};
 
 #[get("/")]
 fn index() -> &'static str {
@@ -33,42 +33,44 @@ fn get_user(state: &State<Model>, user_id: &str) -> Result<Json<User>, NotFound<
 
 
 #[post("/api/account", format = "json", data = "<account>")]
-fn create_account(state: &State<Model>, account: Json<Account>) -> Result<Json<Account>, BadRequest<String>> {
+fn create_account(state: &State<Model>, account: Json<Account>) -> Result<Json<Account>, BadRequest<Json<Error>>> {
     if account.id.is_some() {
-        Err(BadRequest("id must not be provided".to_string()))
+        Err(BadRequest(Json(Error{ message: "id must not be provided".to_string() })))
     }    
     else {
         state
             .new_account(account.account_holder.clone())
             .map(Json)
-            .map_err(|e| BadRequest(e))
+            .map_err(|e| BadRequest(Json(e)))
     }
 }
 
 
 #[get("/api/account/<account>")]
-fn get_account(state: &State<Model>, account: String) -> Result<Json<Account>, NotFound<String>> {
+fn get_account(state: &State<Model>, account: String) -> Result<Json<Account>, NotFound<Json<Error>>> {
     let readable_accounts = state.accounts.read().unwrap();
     match readable_accounts.get(&Uuid::parse_str(&account).unwrap()) {
         Some(account) => { Ok(account.clone().into()) },
-        None => { Err(NotFound(format!("account {} does not exist", account))) },
+        None => { Err(NotFound(Json(Error{ message: format!("account {} does not exist", account) }))) },
     }
 }
 
 
 #[post("/api/deposit", format="json", data="<data>")]
-fn deposit(state: &State<Model>, data: Json<Deposit>) -> Result<Json<Account>, BadRequest<String>> {
+fn deposit(state: &State<Model>, data: Json<Deposit>) -> Result<Json<Account>, BadRequest<Json<Error>>> {
     state
         .apply_deposit(data.into_inner())
-        .map(Json).map_err(|e| BadRequest(e))
+        .map(Json)
+        .map_err(|e| BadRequest(Json(e)))
 }
 
 
 #[post("/api/withdraw", format="json", data="<data>")]
-fn withdraw(state: &State<Model>, data: Json<Widthdrawal>) -> Result<Json<Account>, BadRequest<String>> {
+fn withdraw(state: &State<Model>, data: Json<Widthdrawal>) -> Result<Json<Account>, BadRequest<Json<Error>>> {
     state
         .apply_withdraw(data.into_inner())
-        .map(Json).map_err(|e| BadRequest(e))
+        .map(Json)
+        .map_err(|e| BadRequest(Json(e)))
 }
 
 

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -4,7 +4,7 @@ use rocket::{http::ContentType, local::blocking::Client};
 use rocket::http::Status;
 
 use banking::routing::rocket;
-use banking::model::{Account, Deposit, Money, User, Widthdrawal};
+use banking::model::{Account, Error, Deposit, Money, User, Widthdrawal};
 
 
 struct TestClient {
@@ -70,7 +70,7 @@ impl TestClient {
             Ok(response.into_json::<Account>().unwrap())
         }
         else {
-            Err(response.into_string().unwrap())
+            Err(response.into_json::<Error>().unwrap().message)
         }
     }
 }


### PR DESCRIPTION
For a proper API, we'll need more than a simple string for error values. The "normal" return value is JSON already, so if for nothing else, we want to make sure that the error values are too.

But beyond that, there's a case for more structured response in the future too.